### PR TITLE
Modified HiveOfflineStoreConfig initialization

### DIFF
--- a/feast_hive/hive.py
+++ b/feast_hive/hive.py
@@ -88,10 +88,12 @@ class HiveOfflineStoreConfig(FeastConfigBaseModel):
     """ Specify particular impalad service principal. """
 
     def __init__(self, **data: Any):
-        if "hive_conf" in data and type(data["hive_conf"]) == dict:
-            _hive_conf = DEFAULT_HIVE_CONF
-            _hive_conf.update(data["hive_conf"])
-            data["hive_conf"] = _hive_conf
+        if "hive_conf" not in data:
+            data["hive_conf"] = DEFAULT_HIVE_CONF.copy()
+        elif type(data["hive_conf"]) == dict:
+            data["hive_conf"] = dict(list(DEFAULT_HIVE_CONF.items()) + list(data["hive_conf"].items()))
+        else:
+            raise TypeError("hive_conf should be a dictionary!")
 
         super().__init__(**data)
 


### PR DESCRIPTION
Hi again!

I'm testing current current version of `feast-hive` on a small dataset and it behaved like it does not use default Hive config when no `offline_store.hive_conf` is provided in `feature_store.yaml`.

I debugged `feast-hive` and saw that lines 92-94 aren't executed when no `hive_conf` is provided in `offline_store` section of `feature_store.yaml`. Also, if `hive_conf` is provided, on line 93 we update the `DEFAULT_HIVE_CONF` itself, that can be dangerous if we use different offline stores with different settings (maybe you can use frozendict or something like that for it?).

Here's my quick fix, hope it will be helpful.
^_^