### PR TITLE
Fix the bug when entity_df is sql query

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as f:
     readme = f.read()
 
 INSTALL_REQUIRE = [
-    "feast>=0.14.0",
+    "feast>=0.16.0",
     "impyla[kerberos]>=0.15.0",
 ]
 


### PR DESCRIPTION
Hi, I encountered several errors and fix them.
please check~


This is a detailed commit message.
* add  "SET hive.mapred.mode=nonstrict" to avoid "cartesian products are disabled for safety reasons" error
* add "SET hive.resultset.use.unique.column.names=false" to get column name without table name when pass SQL entity_df.
* uncomment entity_df_columns=entity_schema.keys(). Feast <master> branch require the parameter when call build_point_in_time_query.