### PR TITLE
bugfix: feast-hive was crashing in case of 2 schemas having same-named table

### DIFF
--- a/feast_hive/hive_source.py
+++ b/feast_hive/hive_source.py
@@ -186,13 +186,17 @@ class HiveSource(DataSource):
 
         with HiveConnection(config.offline_store) as conn:
             with conn.cursor() as cursor:
+                database_name = config.offline_store.database if config.offline_store.database else 'default'
                 if self.table is not None:
                     table_splits = self.table.rsplit(".", 1)
-                    database_name = table_splits[0] if len(table_splits) == 2 else None
-                    table_name = (
-                        table_splits[1] if len(table_splits) == 2 else table_splits[0]
-                    )
-
+                    if len(table_splits) == 1:
+                        table_name = table_splits[0]
+                    elif len(table_splits) == 2:
+                        database_name = table_splits[0] if len(table_splits) == 2 else None
+                        table_name = table_splits[1]
+                    else:
+                        raise ValueError(f"Invalid table name {self.table}, "
+                                         f"table name should be [db].[tbl] or just [tbl]")
                     try:
                         return cursor.get_table_schema(table_name, database_name)
                     except:


### PR DESCRIPTION
Hi again! I've encountered with a bug: it I have 2 Hive schemas with same-named table, feast-hive is crashing on `feast apply` on table search and name validation step.

Here's my bugfix for it.
And some code to reproduce the bug could be found here: https://github.com/Felix-neko/feast_sandbox/commit/c8be5ae4550d69830926e029eb3a9b53bd160a27

P.S. I'm a bit overwhelmed with my current work, but It will be extremely cool if you take it to your set of unittest: this place is tricky enough to be unittested.
^_^