### PR TITLE
Support for hiveserver running in http mode

### DIFF
--- a/feast_hive/hive.py
+++ b/feast_hive/hive.py
@@ -88,6 +88,12 @@ class HiveOfflineStoreConfig(FeastConfigBaseModel):
     kerberos_service_name: StrictStr = "impala"
     """ Specify particular impalad service principal. """
 
+    use_http_transport: StrictBool = False
+    """ Use http transport mode """
+
+    http_path: StrictStr = ""
+    """ Path of URL endpoint when use http transport mode """
+
     def __init__(self, **data: Any):
         if "hive_conf" not in data:
             data["hive_conf"] = DEFAULT_HIVE_CONF.copy()


### PR DESCRIPTION
Thank you for great work. 👍 
I've encountered an error that can't connect to our hiveserver running in http mode.
We can't enable http mode because ``use_http_transport``, ``http_path`` are not defined in ``HiveOfflineStoreConfig``.
Please review when you are available.
Thanks!
