### PR TITLE
Failed to feast-materialize if the created_timestamp_column is duplicated

### DIFF
--- a/feast_hive/hive.py
+++ b/feast_hive/hive.py
@@ -162,7 +162,7 @@ class HiveOfflineStore(OfflineStore):
                 "PARTITION BY " + partition_by_join_key_string
             )
         timestamps = [event_timestamp_column]
-        if created_timestamp_column:
+        if created_timestamp_column and created_timestamp_column not in timestamps:
             timestamps.append(created_timestamp_column)
         timestamp_desc_string = " DESC, ".join(timestamps) + " DESC"
         field_string = ", ".join(join_key_columns + feature_name_columns + timestamps)


### PR DESCRIPTION
``feast materialize-incremental`` has failed when ``created_timestamp_column`` is duplicated

* feature defined file

```
stock_hist_source = HiveSource(
    query = """
    SELECT event_timestamp, symbol, high, low, market, volume, foreigner, close
    FROM stock_hist
    """,
...
    timestamp_field="event_timestamp",
    created_timestamp_column="event_timestamp",
)
```

* logs

```
# feast materialize-incremental 2022-08-10T02:52:23
Materializing 1 feature views to 2022-08-10 11:52:23+09:00 into the sqlite online store.
...
/usr/local/lib/python3.9/site-packages/impala/_thrift_gen/TCLIService/TCLIService.py:1736: DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
  iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
Traceback (most recent call last):
  File "/usr/local/bin/feast", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/feast/cli.py", line 467, in materialize_incremental_command
    store.materialize_incremental(
  File "/usr/local/lib/python3.9/site-packages/feast/usage.py", line 280, in wrapper
    raise exc.with_traceback(traceback)
  File "/usr/local/lib/python3.9/site-packages/feast/usage.py", line 269, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/feast/feature_store.py", line 877, in materialize_incremental
    provider.materialize_single_feature_view(
  File "/usr/local/lib/python3.9/site-packages/feast/infra/passthrough_provider.py", line 142, in materialize_single_feature_view
    table = offline_job.to_arrow()
  File "/usr/local/lib/python3.9/site-packages/feast/infra/offline_stores/offline_store.py", line 67, in to_arrow
    return self._to_arrow_internal()
  File "/usr/local/lib/python3.9/site-packages/feast_hive/hive.py", line 332, in _to_arrow_internal
    return pa.Table.from_batches(pa_batches, schema)
  File "/usr/local/lib/python3.9/site-packages/impala/interface.py", line 179, in __exit__
    reraise(exc_type, exc_val, exc_tb)
  File "/usr/local/lib/python3.9/site-packages/six.py", line 703, in reraise
    raise value
  File "/usr/local/lib/python3.9/site-packages/feast_hive/hive.py", line 320, in _to_arrow_internal
    cursor.execute(query)
  File "/usr/local/lib/python3.9/site-packages/impala/hiveserver2.py", line 340, in execute
    self.execute_async(operation, parameters=parameters,
  File "/usr/local/lib/python3.9/site-packages/impala/hiveserver2.py", line 387, in execute_async
    self._execute_async(op)
  File "/usr/local/lib/python3.9/site-packages/impala/hiveserver2.py", line 406, in _execute_async
    operation_fn()
  File "/usr/local/lib/python3.9/site-packages/impala/hiveserver2.py", line 382, in op
    op = self.session.execute(self._last_operation_string,
  File "/usr/local/lib/python3.9/site-packages/impala/hiveserver2.py", line 1224, in execute
    return self._operation('ExecuteStatement', req, False)
  File "/usr/local/lib/python3.9/site-packages/impala/hiveserver2.py", line 1145, in _operation
    resp = self._rpc(kind, request, retry_on_http_error)
  File "/usr/local/lib/python3.9/site-packages/impala/hiveserver2.py", line 1082, in _rpc
    err_if_rpc_not_ok(response)
  File "/usr/local/lib/python3.9/site-packages/impala/hiveserver2.py", line 780, in err_if_rpc_not_ok
    raise HiveServer2Error(resp.status.errorMessage)
impala.error.HiveServer2Error: Error while compiling statement: FAILED: SemanticException [Error 10007]: Ambiguous column reference event_timestamp in t2
```

